### PR TITLE
Limit connection earlier

### DIFF
--- a/Sources/KituraNet/HTTP/HTTPRequestHandler.swift
+++ b/Sources/KituraNet/HTTP/HTTPRequestHandler.swift
@@ -79,7 +79,7 @@ internal class HTTPRequestHandler: ChannelInboundHandler, RemovableChannelHandle
         if errorResponseSent { return }
         switch request {
         case .head(let header):
-            server.connectionCount.add(1)
+            _ = server.connectionCount.add(1)
             if let connectionLimit = server.options.connectionLimit,
                 server.connectionCount.load() > connectionLimit {
                 // Reaching connection limit: closing now.
@@ -92,7 +92,7 @@ internal class HTTPRequestHandler: ChannelInboundHandler, RemovableChannelHandle
                 } catch {
                     Log.error("Failed to send error response")
                 }
-                context.close()
+                context.close(promise: nil)
                 return
             }
             serverRequest = HTTPServerRequest(channel: context.channel, requestHead: header, enableSSL: enableSSLVerification)
@@ -109,7 +109,7 @@ internal class HTTPRequestHandler: ChannelInboundHandler, RemovableChannelHandle
                     } catch {
                         Log.error("Failed to send error response")
                     }
-                    context.close()
+                    context.close(promise: nil)
                 }
             }
             serverRequest = HTTPServerRequest(channel: context.channel, requestHead: header, enableSSL: enableSSLVerification)
@@ -203,6 +203,6 @@ internal class HTTPRequestHandler: ChannelInboundHandler, RemovableChannelHandle
     }
 
     func channelInactive(context: ChannelHandlerContext) {
-        server.connectionCount.sub(1)
+        _ = server.connectionCount.sub(1)
     }
 }


### PR DESCRIPTION
As pointed by @davidde94 (https://github.com/Kitura/Kitura-NIO/issues/242), the connection should be closed earlier than on the end of the request.
This avoid dumping massive amount of data before checking the connection limit.